### PR TITLE
Add link to NETFiddle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Examples.Doublets.CRUD/issues/19
-Your prepared branch: issue-19-24f5daee
-Your prepared working directory: /tmp/gh-issue-solver-1757775445780
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Examples.Doublets.CRUD/issues/19
+Your prepared branch: issue-19-24f5daee
+Your prepared working directory: /tmp/gh-issue-solver-1757775445780
+
+Proceed.

--- a/csharp/README.ru.md
+++ b/csharp/README.ru.md
@@ -9,7 +9,7 @@
 * [.NET 5+ или .NET Core 2.2+](https://dotnet.microsoft.com/download)
 * NuGet пакет [Platform.Data.Doublets](https://www.nuget.org/packages/Platform.Data.Doublets) с версией 0.6.0 или выше
 
-## [Код](https://github.com/linksplatform/Examples.Doublets.CRUD.DotNet/blob/master/csharp/Program.cs) | [Запустить .NET fiddle](https://dotnetfiddle.net/Y7Zvt0)
+## [Код](https://github.com/linksplatform/Examples.Doublets.CRUD.DotNet/blob/master/csharp/Program.cs) | [Запустить .NET fiddle](https://dotnetfiddle.net/ERHBKA)
 
 ```C#
 using System;


### PR DESCRIPTION
## Summary

Updated Russian README to use the same NETFiddle link as the English version.

- Changed NETFiddle link in Russian README from Y7Zvt0 to ERHBKA to match the English version
- Both English and Russian versions now point to the same updated fiddle (https://dotnetfiddle.net/ERHBKA)
- Resolves issue #19 which requested updating both language versions

## Test plan

- [x] Verify both README files contain the same NETFiddle link
- [x] Check that the NETFiddle link matches the most recent update from commit 2048ae6
- [x] Confirm the change maintains consistency between language versions

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #19